### PR TITLE
add demo mode for when no midi cables are connected

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,7 +57,7 @@ const App = (props: AppProps) => {
   };
 
   const connectMidi = async () => {
-    return monologueController.connect();
+    return monologueController.connect(false);
   };
 
   const [patchName, setPatchName] = useState(() => korgProgramDump.patchName);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,9 @@ const data: KorgProgramDump = {
   ...blob,
 };
 
-monologueController.connect().then(() => {
+
+
+monologueController.connect(true).then(() => {
   ReactDOM.render(
     <React.StrictMode>
       <App korgProgramDump={data} monologueController={monologueController} />

--- a/src/midi/midi.ts
+++ b/src/midi/midi.ts
@@ -8,15 +8,20 @@ export default class MonologueController {
     console.log("monologue controller is initialised");
   }
 
+  demoMode = false;
+
   registeredParameters = {};
   onParameterChange = (parameter: Parameter, callback: Function) => {
     this.registeredParameters[parameter.ID] = {
       parameter,
       callback,
     };
-  }
+  };
 
   handleParameterChange = (e: any) => {
+    if (this.demoMode) {
+      return;
+    }
     Object.keys(this.registeredParameters).map((id) => {
       const { parameter, callback } = this.registeredParameters[id];
 
@@ -31,36 +36,55 @@ export default class MonologueController {
       const fourPoleValue = (value / 123) * 3;
 
       let finalValue;
-      if(parameter.type === ParameterType.LINEAR) {
+      if (parameter.type === ParameterType.LINEAR) {
         finalValue = knobValue;
       }
 
-      if(parameter.type === ParameterType.THREE_POLE) {
+      if (parameter.type === ParameterType.THREE_POLE) {
         finalValue = threePoleValue;
       }
 
-      if(parameter.type === ParameterType.FOUR_POLE) {
+      if (parameter.type === ParameterType.FOUR_POLE) {
         finalValue = fourPoleValue;
       }
 
       callback(parameter, finalValue);
     });
-  }
+  };
 
-  connect = async () => {
+  connectDemo = async () => {
+    this.demoMode = true;
+    console.log("demo mode");
+  };
+
+  connect = async (allowDemoFallback: boolean) => {
     console.log("connecting to monologue");
-    await WebMidi.enable({ sysex: true })
-
+    await WebMidi.enable({ sysex: true });
+    if (WebMidi.inputs.length <= 0) {
+      if (allowDemoFallback) {
+        this.connectDemo();
+        return;
+      } else {
+        throw new Error(
+          "no WebMidi inputs found. Check midi cable. Try sending messages here for debugging: https://www.midimonitor.com/ "
+        );
+      }
+    }
     const channelIn = WebMidi.inputs[0].channels[1];
-    channelIn.addListener("midimessage", this.handleParameterChange);
-  }
+    channelIn?.addListener("midimessage", this.handleParameterChange);
+  };
 
   setParameter = (parameter: Parameter, value: number) => {
+    if (this.demoMode) {
+      return;
+    }
     const channelOut = WebMidi.outputs[0].channels[1];
     const finalValue = Math.round((value / 1023) * 127);
 
-    console.log(`setting parameter ${parameter.name} to ${finalValue}: ${value}`);
+    console.log(
+      `setting parameter ${parameter.name} to ${finalValue}: ${value}`
+    );
 
     channelOut.send([MESSAGE_NUMBER, parameter.ID, finalValue]);
-  }
+  };
 }


### PR DESCRIPTION
Added a demo mode so the app can launch with no midi cables. 

Clicking connect with no cables will still throw a fatal error tho.