### PR TITLE
Fix Monologue flushing to UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import "./App.css";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Master } from "./panelSections/Master";
 import { VCO1 } from "./panelSections/VCO1";
 import { Mixer } from "./panelSections/Mixer";
@@ -14,22 +14,32 @@ import afxAcid from "./patches/<afx acid3>.json";
 import injection from "./patches/Injection.json";
 import fake3OSC from "./patches/Fake3OSC.json";
 import TeeVeeSaw from "./patches/TeeVeeSaw.json";
-import { initialiseParamState, ParamState } from "./paramState";
+import { initialiseParamState, ParamState, ParameterStateMap } from "./paramState";
 import MonologueController from "./midi/midi";
 
 const getMergedParamState = (state:ParamState, setParamState, monologueController:MonologueController) => (parameter: Parameter, finalValue: number) => {
+  const paramStateMap:ParameterStateMap = {
+    parameter: parameter,
+    value: finalValue,
+  };
+
   setParamState({
     ...state,
-    [parameter.name]: finalValue
-  })
+    [parameter.name]: paramStateMap,
+  });
 }
 
 const getMergedParamStateForCallback = (state:ParamState, setParamState, monologueController:MonologueController) => (parameter: Parameter) => (finalValue: number) => {
   monologueController.setParameter(parameter, finalValue);
 
+  const paramStateMap:ParameterStateMap = {
+    parameter: parameter,
+    value: finalValue,
+  };
+
   setParamState({
     ...state,
-    [parameter.name]: finalValue
+    [parameter.name]: paramStateMap,
   })
 };
 
@@ -62,6 +72,10 @@ const App = (props: AppProps) => {
 
   const [patchName, setPatchName] = useState(() => korgProgramDump.patchName);
   const [paramState, setParamState] = useState(() => initialiseParamState(korgProgramDump));
+
+  useEffect(() => {
+    flushStateToMonologue(paramState, monologueController);
+  },[paramState, monologueController]);
 
   const appliedParamState = getMergedParamState(paramState, setParamState, monologueController);
   const setParamViaCallback = getMergedParamStateForCallback(paramState, setParamState, monologueController);

--- a/src/paramState.ts
+++ b/src/paramState.ts
@@ -2,34 +2,34 @@ import { constants } from "buffer";
 import { Parameters, Parameter } from "./ParameterHash";
 import { KorgProgramDump } from "./types";
 
-interface ParamterStateMap {
+export interface ParameterStateMap {
   parameter: Parameter;
   value: number;
 }
 
 export interface ParamState {
-  drive: ParamterStateMap;
-  vco1Shape: ParamterStateMap;
-  vco1Wave: ParamterStateMap;
-  vco2Octave: ParamterStateMap;
-  vco2Wave: ParamterStateMap;
-  vco2Duty: ParamterStateMap;
-  vco2Pitch: ParamterStateMap;
-  vco2Shape: ParamterStateMap;
-  vco1Level: ParamterStateMap;
-  vco2Level: ParamterStateMap;
-  cutoff: ParamterStateMap;
-  resonance: ParamterStateMap;
-  envType: ParamterStateMap;
-  envAttack: ParamterStateMap;
-  envDecay: ParamterStateMap;
-  envIntensity: ParamterStateMap;
-  envTarget: ParamterStateMap;
-  lfoWave: ParamterStateMap;
-  lfoMode: ParamterStateMap;
-  lfoRate: ParamterStateMap;
-  lfoIntensity: ParamterStateMap;
-  lfoTarget: ParamterStateMap;
+  drive: ParameterStateMap;
+  vco1Shape: ParameterStateMap;
+  vco1Wave: ParameterStateMap;
+  vco2Octave: ParameterStateMap;
+  vco2Wave: ParameterStateMap;
+  vco2Duty: ParameterStateMap;
+  vco2Pitch: ParameterStateMap;
+  vco2Shape: ParameterStateMap;
+  vco1Level: ParameterStateMap;
+  vco2Level: ParameterStateMap;
+  cutoff: ParameterStateMap;
+  resonance: ParameterStateMap;
+  envType: ParameterStateMap;
+  envAttack: ParameterStateMap;
+  envDecay: ParameterStateMap;
+  envIntensity: ParameterStateMap;
+  envTarget: ParameterStateMap;
+  lfoWave: ParameterStateMap;
+  lfoMode: ParameterStateMap;
+  lfoRate: ParameterStateMap;
+  lfoIntensity: ParameterStateMap;
+  lfoTarget: ParameterStateMap;
 }
 
 export const initialiseParamState = (korgProgramDump: KorgProgramDump): ParamState => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4483,11 +4483,6 @@
   "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   "version" "1.0.0"
 
-"fsevents@^2.3.2", "fsevents@~2.3.2":
-  "integrity" "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
-  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
-  "version" "2.3.2"
-
 "function-bind@^1.1.1":
   "integrity" "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
   "resolved" "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"


### PR DESCRIPTION
The monologue -> react ui wasn't fully wired up, and had some bugs in creating the correct state format. This PR fixes that directional communications, allowing for parameter changes on the monologue to be represented in the UI again. Note that parameters that go into the negative still break, as the mapping isn't finished yet. The INT param is one of these.