### PR TITLE
Fix knob and switch mapping, allow for working two way communication

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,7 +50,8 @@ import VideoGame from "./patches/dutch-bass/Video Game.json";
 import { initialiseParamState, ParamState, ParameterStateMap } from "./paramState";
 import MonologueController from "./midi/midi";
 
-const getMergedParamState = (state: ParamState, setParamState, monologueController: MonologueController) => (parameter: Parameter, finalValue: number) => {
+const getMergedParamState = (state: ParamState, setParamState, monologueController: MonologueController) =>
+  (parameter: Parameter, finalValue: number) => {
   const paramStateMap: ParameterStateMap = {
     parameter: parameter,
     value: finalValue,
@@ -62,7 +63,9 @@ const getMergedParamState = (state: ParamState, setParamState, monologueControll
   });
 }
 
-const getMergedParamStateForCallback = (state: ParamState, setParamState, monologueController: MonologueController) => (parameter: Parameter) => (finalValue: number) => {
+const getMergedParamStateForCallback = (state: ParamState, setParamState, monologueController: MonologueController) =>
+  (parameter: Parameter) =>
+  (finalValue: number) => {
   monologueController.setParameter(parameter, finalValue);
 
   const paramStateMap: ParameterStateMap = {
@@ -91,11 +94,9 @@ const App = (props: AppProps) => {
   } = props;
 
   const selectPatch = (patch: KorgProgramDump) => {
-
-    setPatchName(patch.patchName);
-
     const state = initialiseParamState(patch);
 
+    setPatchName(patch.patchName);
     setParamState(state);
     flushStateToMonologue(state, monologueController);
   };
@@ -106,10 +107,6 @@ const App = (props: AppProps) => {
 
   const [patchName, setPatchName] = useState(() => korgProgramDump.patchName);
   const [paramState, setParamState] = useState(() => initialiseParamState(korgProgramDump));
-
-  useEffect(() => {
-    flushStateToMonologue(paramState, monologueController);
-  }, [paramState, monologueController]);
 
   const appliedParamState = getMergedParamState(paramState, setParamState, monologueController);
   const setParamViaCallback = getMergedParamStateForCallback(paramState, setParamState, monologueController);

--- a/src/controlGroups/Knob.tsx
+++ b/src/controlGroups/Knob.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState, memo } from "react";
 import {
   cursorCoordsToDegrees,
-  degreesToParam,
-  paramToDegrees,
+  rangeMap,
 } from "../utils";
 
 interface KnobProps {
@@ -17,11 +16,13 @@ interface KnobProps {
 
 const Knob = memo((props: KnobProps) => {
   const paramMin = props.paramMin || 0;
-  const paramMax = props.paramMax || 1023;
+  const paramMax = props.paramMax || 127;
   const fullAngle = props.fullAngle || 260;
   const startAngle: number = (360 - fullAngle) / 2;
   const endAngle: number = startAngle + fullAngle;
-  const degrees: number = paramToDegrees(
+
+
+  const degrees: number = rangeMap(
     paramMin,
     paramMax,
     startAngle,
@@ -57,13 +58,13 @@ const Knob = memo((props: KnobProps) => {
         endAngle
       );
 
-      const currentValue = degreesToParam(
-        paramMin,
-        paramMax,
+      const currentValue = Math.floor(rangeMap(
         startAngle,
         endAngle,
+        paramMin,
+        paramMax,
         degrees
-      );
+      ));
       props.onChange(currentValue);
     };
     document.addEventListener("mousemove", moveHandler);

--- a/src/controlGroups/SwitchContainer.tsx
+++ b/src/controlGroups/SwitchContainer.tsx
@@ -13,6 +13,22 @@ interface WaveProps {
 }
 const SwitchContainer = (props: WaveProps) => {
   const labels = props.labels || [<Saw />, <Triangle />, <Square />];
+
+  let transposedValue;
+  switch(props.value) {
+    case 127:
+      transposedValue = 2;
+      break;
+    case 64:
+      transposedValue = 1;
+      break;
+    case 0:
+      transposedValue = 0;
+      break;
+    default:
+      transposedValue = props.value;
+  }
+
   return (
     <div
       className={`control-group${
@@ -21,7 +37,7 @@ const SwitchContainer = (props: WaveProps) => {
     >
       <div className="control-wrapper">
         <Switch
-          value={props.value}
+          value={transposedValue}
           numPositions={3}
           vertical
           onChange={props.onChange}

--- a/src/controlGroups/VCO2Octave.tsx
+++ b/src/controlGroups/VCO2Octave.tsx
@@ -25,6 +25,24 @@ interface WaveProps {
 }
 
 const VCO2Octave = (props: WaveProps) => {
+  let transposedValue;
+  switch(props.value) {
+    case 127:
+      transposedValue = 3;
+      break;
+    case 84:
+      transposedValue = 2;
+      break;
+    case 42:
+      transposedValue = 1;
+      break;
+    case 0:
+      transposedValue = 0;
+      break;
+    default:
+      transposedValue = props.value;
+  }
+
   return (
     <div
       className={`control-group${
@@ -33,14 +51,14 @@ const VCO2Octave = (props: WaveProps) => {
     >
       <div className="control-wrapper">
         <Switch
-          value={props.value}
+          value={transposedValue}
           numPositions={4}
           vertical
           onChange={props.onChange}
         />
       </div>
       <p className="control-label label">{props.paramName}</p>
-      <OscOctaveLeds octave={props.value} />
+      <OscOctaveLeds octave={transposedValue} />
     </div>
   );
 };

--- a/src/midi/midi.ts
+++ b/src/midi/midi.ts
@@ -1,7 +1,7 @@
 import { WebMidi } from "webmidi";
-import { ParameterType, ParameterHash, Parameter } from "../ParameterHash";
+import { Parameter } from "../ParameterHash";
 
-const MESSAGE_NUMBER = 176;
+const PARAM_CHANGE_MESSAGE = 179;
 
 export default class MonologueController {
   constructor() {
@@ -22,34 +22,32 @@ export default class MonologueController {
     if (this.demoMode) {
       return;
     }
+
     Object.keys(this.registeredParameters).map((id) => {
       const { parameter, callback } = this.registeredParameters[id];
+      const [message, messageParameter, value] = e.data; // eslint-disable-line @typescript-eslint/no-unused-vars
 
-      const [_, messageParameter, value] = e.data; // eslint-disable-line @typescript-eslint/no-unused-vars
+      // We only want to listen to param change messages
+      if(message !== PARAM_CHANGE_MESSAGE) return null;
 
       if (messageParameter !== parameter.ID) {
-        return;
+        return null;
       }
 
-      const knobValue = Math.round((value / 123) * 1027);
-      const threePoleValue = (value / 123) * 2;
-      const fourPoleValue = (value / 123) * 3;
-
-      let finalValue;
-      if (parameter.type === ParameterType.LINEAR) {
-        finalValue = knobValue;
-      }
-
-      if (parameter.type === ParameterType.THREE_POLE) {
-        finalValue = threePoleValue;
-      }
-
-      if (parameter.type === ParameterType.FOUR_POLE) {
-        finalValue = fourPoleValue;
-      }
-
-      callback(parameter, finalValue);
+      return callback(parameter, value);
     });
+  };
+
+  setParameter = (parameter: Parameter, value: number) => {
+    if (this.demoMode) {
+      return;
+    }
+
+    const channelOut = WebMidi.outputs[0].channels[1];
+
+    console.log(`setting parameter ${parameter.name}:${parameter.ID} to ${value}`);
+
+    channelOut.sendControlChange(parameter.ID, value)
   };
 
   connectDemo = async () => {
@@ -70,21 +68,9 @@ export default class MonologueController {
         );
       }
     }
+
     const channelIn = WebMidi.inputs[0].channels[1];
     channelIn?.addListener("midimessage", this.handleParameterChange);
   };
 
-  setParameter = (parameter: Parameter, value: number) => {
-    if (this.demoMode) {
-      return;
-    }
-    const channelOut = WebMidi.outputs[0].channels[1];
-    const finalValue = Math.round((value / 1023) * 127);
-
-    console.log(
-      `setting parameter ${parameter.name} to ${finalValue}: ${value}`
-    );
-
-    channelOut.send([MESSAGE_NUMBER, parameter.ID, finalValue]);
-  };
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,28 +1,13 @@
-export const paramToDegrees = (
-  paramMin: number,
-  paramMax: number,
-  startAngle: number,
-  endAngle: number,
-  paramValue: number
+export const rangeMap = (
+  valueMin: number,
+  valueMax: number,
+  rangeMin: number,
+  rangeMax: number,
+  value: number
 ) => {
-  return Math.floor(
-    ((paramValue - paramMin) * (endAngle - startAngle)) /
-      (paramMax - paramMin) +
-      startAngle
-  );
-};
-
-export const degreesToParam = (
-  paramMin: number,
-  paramMax: number,
-  startAngle: number,
-  endAngle: number,
-  degrees: number
-) => {
-  return Math.floor(
-    ((degrees - startAngle) * (paramMax - paramMin)) / (endAngle - startAngle) +
-      paramMin
-  );
+  return (value - valueMin)
+  / (valueMax - valueMin)
+  * (rangeMax - rangeMin) + rangeMin;
 };
 
 export const cursorCoordsToDegrees = (


### PR DESCRIPTION
This PR makes a few fixes and a few changes to allow for working two way communication between the synth and the computer. 

The biggest change here is how the parameters are handled. Rather than remapping the values as they enter or leave the state, the state is accurate to the synth. Then the knob and switch setup remap the real values to whatever they wish to use internally. This makes managing the state a lot easier, and keeps the value mapping to be the responsibility of the components that display it.

I also found that the midi write function wasn't working properly, so I swapped to WEBMIDI.js's control change function instead, which does work.